### PR TITLE
Fix build on BSD: include <sys/endian.h> in adnsmodule.c

### DIFF
--- a/adnsmodule.c
+++ b/adnsmodule.c
@@ -12,6 +12,9 @@ any later version.
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#  include <sys/endian.h>
+#endif
 
 static PyObject *ErrorObject;
 static PyObject *NotReadyError;


### PR DESCRIPTION
Adding BSD support by conditionally adding <sys/endian.h>